### PR TITLE
fix: postgres container running condition

### DIFF
--- a/cli-data/build-scripts/899c20f5-63d6-47fc-9250-32b5cd2c3aef
+++ b/cli-data/build-scripts/899c20f5-63d6-47fc-9250-32b5cd2c3aef
@@ -14,7 +14,12 @@ docker-compose run --rm web bash -c '
 ' | awk -v prefix="[backend]" '{ print prefix, $0 }' &&
 docker-compose run web rake spree_sample:load | awk -v prefix="[backend]" '{ print prefix, $0 }'
 docker-compose up redis postgres | awk -v prefix="[backend]" '{ print prefix, $0 }' &
-(while [ "`docker inspect -f {{.State.Running}} backend_postgres_1`" != "true" ]; do     sleep 2; done &&
-yarn install &&
-yarn build &&
-bin/rails s) | awk -v prefix="[backend]" '{ print prefix, $0 }'
+(
+  while
+    [ "`docker inspect -f {{.State.Running}} backend_postgres_1`" != "true" ] &&
+    [ "`docker inspect -f {{.State.Running}} backend-postgres-1`" != "true" ];
+  do sleep 2; done &&
+  yarn install &&
+  yarn build &&
+  bin/rails s
+) | awk -v prefix="[backend]" '{ print prefix, $0 }'

--- a/cli-data/build-scripts/da7cfc54-c270-46c8-96c5-c54181e0424c
+++ b/cli-data/build-scripts/da7cfc54-c270-46c8-96c5-c54181e0424c
@@ -13,7 +13,12 @@ docker-compose run --rm web bash -c '
   rm -rf tmp/latest.dump
 ' | awk -v prefix="[backend]" '{ print prefix, $0 }'
 docker-compose up redis postgres | awk -v prefix="[backend]" '{ print prefix, $0 }' &
-(while [ "`docker inspect -f {{.State.Running}} backend_postgres_1`" != "true" ]; do     sleep 2; done &&
-yarn install &&
-yarn build &&
-bin/rails s) | awk -v prefix="[backend]" '{ print prefix, $0 }'
+(
+  while
+    ["`docker inspect -f {{.State.Running}} backend_postgres_1`" != "true" ] &&
+    ["`docker inspect -f {{.State.Running}} backend-postgres-1`" != "true" ];
+  do sleep 2; done &&
+  yarn install &&
+  yarn build &&
+  bin/rails s
+) | awk -v prefix="[backend]" '{ print prefix, $0 }'


### PR DESCRIPTION
This PR fixes the infinite loop of waiting for the postgres container to start up.

The issue is caused by the fact that docker-compose v1 uses underscores in auto-generated container names (`backend_postgres_1`) while v2 uses dashes (`backend-postgres-1`). Currently the script was only expecting underscores version causing an infinite loop for v2 users.

The proposed solution: check for both options.