### PR TITLE
feat: update next storefront integration scripts

### DIFF
--- a/cli-data/build-scripts/76352e58-4a43-4af1-8f3e-88e90a79f6f1
+++ b/cli-data/build-scripts/76352e58-4a43-4af1-8f3e-88e90a79f6f1
@@ -1,6 +1,6 @@
 cd $SPREE_CLI_PROJECT_NAME
 cd $SPREE_CLI_PATH_INTEGRATION
-cp packages/spree/.env.template site/.env.local
+cp framework/spree/.env.template .env.local
 yarn install | awk -v prefix="[frontend]" '{ print prefix, $0 }'
 for i in `seq 1 50`; do yarn dev | awk -v prefix="[frontend]" '{ print prefix, $0 }'; done
 # This is workaround since next is not working properly

--- a/cli-data/integrations/data.json
+++ b/cli-data/integrations/data.json
@@ -14,7 +14,7 @@
   {
     "id": "76352e58-4a43-4af1-8f3e-88e90a79f6f1",
     "name": "Next.js Commerce",
-    "gitRepositoryURL": "https://github.com/vercel/commerce",
+    "gitRepositoryURL": "https://github.com/spree/nextjs-commerce",
     "documentationURL": "https://user-docs.spreecommerce.org",
     "buildScriptPath": "/build-scripts/76352e58-4a43-4af1-8f3e-88e90a79f6f1",
     "runScriptPath": "/run-scripts/76352e58-4a43-4af1-8f3e-88e90a79f6f1",


### PR DESCRIPTION
This PR changes the next storefront repo from the original nextjs-commerce to the fork that is compatible with spree. It also updates the next build script